### PR TITLE
Add ignore_nils: option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,17 @@ end
 
 It works with more than one argument (`a.zip(b,c)`) as well as with zero arguments (`a.zip()`).
 
+You can also ask it to disregard nil values:
+
+```ruby
+a = {x: 1, y: 2}
+b = {y: 3, z: 4}
+a.zip(b, ignore_nils: true) do |key, value_a, value_b|
+  p [key, value_a, value_b]
+  # Yields [:x, 1]
+  #        [:y, 2, 3]
+  #        [:z, 4]
+end
+```
+
 If arguments are not `Hash`es, but accept `to_h`, they will be converted automatically before zipping.

--- a/lib/hash-zip.rb
+++ b/lib/hash-zip.rb
@@ -1,6 +1,6 @@
 # Enumerable#zip is nonsense when applied to Hashes
 class Hash
-  def zip(*args)
+  def zip(*args, ignore_nils: false)
     sources = [self]
     args.each do |arg|
       if arg.is_a?(Hash)
@@ -12,13 +12,21 @@ class Hash
     output_keys = sources.flat_map(&:keys).uniq
     if block_given?
       output_keys.each do |key|
-        yield(key, *sources.map{|source| source[key]})
+        values = sources.map{|source| source[key]}
+        if ignore_nils
+          values = values.compact
+        end
+        yield(key, *values)
       end
       nil
     else
       result = {}
       output_keys.each do |key|
-        result[key] = sources.map{|source| source[key]}
+        values = sources.map{|source| source[key]}
+        if ignore_nils
+          values = values.compact
+        end
+        result[key] = values
       end
       result
     end

--- a/spec/hash_zip_spec.rb
+++ b/spec/hash_zip_spec.rb
@@ -58,4 +58,27 @@ describe "Hash#zip" do
       x: [1,4], y: [2,nil], z: [3,5], w: [nil,6]
     })
   end
+
+  it "allows ignoring nils" do
+    a = {x: 1, y: 2}
+    b = {x: 3, z: 4}
+    expect(a.zip(b, ignore_nils: true)).to eq({
+      x: [1,3], y: [2], z: [4]
+    })
+  end
+
+  it "returns nil, yields for each compacted item when passed a block" do
+    a = {x: 1, y: 2, z: 3}
+    b = {x: 4, z: 5, w: 6}
+    calls = []
+    expect(a.zip(b, ignore_nils: true){|*args|
+      calls << args
+    }).to eq(nil)
+    expect(calls).to eq([
+      [:x, 1, 4],
+      [:y, 2],
+      [:z, 3, 5],
+      [:w, 6],
+    ])
+  end
 end


### PR DESCRIPTION
This is a simple option I had a use case for when dealing with partial data.

If you think this shouldn't be an option, and instead manual accruing of values with a block (to call `.compact`) is preferable, I understand.